### PR TITLE
Ext. connections moved to pub-oapi-tools-common

### DIFF
--- a/enqueue_new_pubmed_items_elements.py
+++ b/enqueue_new_pubmed_items_elements.py
@@ -1,48 +1,46 @@
 # LinkOut submission documentation
 # https://www.ncbi.nlm.nih.gov/books/NBK3812/
 
-import boto3
+from pub_oapi_tools_common import parameter_store_connect
 import pymysql
 import pyodbc
 import submit_new_pubmed_items
 
 submission_threshold = 250
-session = boto3.Session()
+
+
+# =========================
+creds = {
+    'elements_db': {
+        'folder': 'pub-oapi-tools/elements-reporting-db',
+        'env': 'prod'},
+    'linkout_db': {
+        'folder': 'pub-oapi-tools/tools-rds',
+        'env': 'prod',
+        'names': ['server', 'pubmed-linkout-db', 'user', 'password']}
+}
+
+creds = parameter_store_connect.get_parameters(creds)
 
 
 # =========================
 # Get Connections
-
-def get_ssm_parameters(folder, names):
-    print("Connect to SSM for parameters")
-    ssm_client = session.client(service_name='ssm', region_name='us-west-2')
-
-    param_names = [f"{folder}{name}" for name in names]
-    response = ssm_client.get_parameters(Names=param_names, WithDecryption=True)
-
-    param_values = {
-        (param['Name'].split('/')[-1]): param['Value']
-        for param in response['Parameters']}
-
-    return param_values
-
-
-def get_logging_db_connection(creds):
+def get_logging_db_connection(linkout_db):
     return pymysql.connect(
-        host=creds['server'],
-        user=creds['user'],
-        password=creds['password'],
-        database=creds['pubmed-linkout-db'],
+        host=linkout_db['server'],
+        user=linkout_db['user'],
+        password=linkout_db['password'],
+        database=linkout_db['pubmed-linkout-db'],
         cursorclass=pymysql.cursors.DictCursor)
 
 
-def get_elements_report_db_connection(creds):
+def get_elements_report_db_connection(elements_db):
     mssql_conn = pyodbc.connect(
-        driver=creds['driver'],
-        server=(creds['server'] + ',1433'),
-        database=creds['database'],
-        uid=creds['user'],
-        pwd=creds['password'],
+        driver=elements_db['driver'],
+        server=(elements_db['server'] + ',1433'),
+        database=elements_db['database'],
+        uid=elements_db['user'],
+        pwd=elements_db['password'],
         trustservercertificate='yes')
     mssql_conn.autocommit = True  # Required when queries use TRANSACTION
     return mssql_conn
@@ -50,23 +48,16 @@ def get_elements_report_db_connection(creds):
 
 # =========================
 def main():
-    elements_db_creds = get_ssm_parameters(
-        folder="/pub-oapi-tools/elements-reporting-db/prod/",
-        names=['server', 'database', 'user', 'password', 'driver'])
-
-    tools_rds_creds = get_ssm_parameters(
-        folder="/pub-oapi-tools/tools-rds/prod/",
-        names=['server', 'pubmed-linkout-db', 'user', 'password'])
 
     # Get the pubs we've already submitted - returns a list of eschol_ids.
-    submitted_ids = get_previous_pubmed_submissions(tools_rds_creds)
+    submitted_ids = get_previous_pubmed_submissions(creds['linkout_db'])
 
     # Get newly-added eSchol pubmed items;
     # Add them to the logging db
     # Check the total number of enqueued items
-    new_pubmed_items = get_new_pmid_pubs(elements_db_creds, submitted_ids)
+    new_pubmed_items = get_new_pmid_pubs(creds['elements_db'], submitted_ids)
     if new_pubmed_items:
-        total_enqueued = add_new_items_to_logging_db(tools_rds_creds, new_pubmed_items)
+        total_enqueued = add_new_items_to_logging_db(creds['linkout_db'], new_pubmed_items)
     else:
         print("No new pmid publications in eScholarship. Exiting.")
         exit(1)

--- a/enqueue_new_pubmed_items_elements.py
+++ b/enqueue_new_pubmed_items_elements.py
@@ -1,42 +1,27 @@
 # LinkOut submission documentation
 # https://www.ncbi.nlm.nih.gov/books/NBK3812/
 
-from pub_oapi_tools_common import aws_lambda
 from pub_oapi_tools_common import ucpms_db
 from pub_oapi_tools_common import pub_oapi_tools_db
 
-import submit_new_pubmed_items
-
 submission_threshold = 250
-
-
-# =========================
-creds = {
-    'elements_db': {
-        'folder': 'pub-oapi-tools/elements-reporting-db',
-        'env': 'prod'},
-    'linkout_db': {
-        'folder': 'pub-oapi-tools/tools-rds',
-        'env': 'prod',
-        'names': ['server', 'pubmed-linkout-db', 'user', 'password']}
-}
-
-creds = aws_lambda.get_parameters(creds)
-creds['linkout_db']['database'] = creds['linkout_db']['pubmed-linkout-db']
+pub_oapi_tools_env = "prod"
+pub_oapi_tools_db_name = "pubmed-linkout-db"
+ucpms_db_env = "prod"
 
 
 # =========================
 def main():
 
     # Get the pubs we've already submitted - returns a list of eschol_ids.
-    submitted_ids = get_previous_pubmed_submissions(creds['linkout_db'])
+    submitted_ids = get_previous_pubmed_submissions()
 
     # Get newly-added eSchol pubmed items
     # Add them to the logging db
     # Check the total number of enqueued items
-    new_pubmed_items = get_new_pmid_pubs(creds['elements_db'], submitted_ids)
+    new_pubmed_items = get_new_pmid_pubs(submitted_ids)
     if new_pubmed_items:
-        total_enqueued = add_new_items_to_logging_db(creds['linkout_db'], new_pubmed_items)
+        total_enqueued = add_new_items_to_logging_db(new_pubmed_items)
     else:
         print("No new pmid publications in eScholarship. Exiting.")
         exit(1)
@@ -44,6 +29,7 @@ def main():
     print(f"Including the new items, {total_enqueued} total items are enqueued for submission.")
     if total_enqueued >= submission_threshold:
         print(f"Total enqueued items over the threshold ({submission_threshold}): Moving to submission step.\n")
+        import submit_new_pubmed_items
         submit_new_pubmed_items.main()
     else:
         print(f"Total enqueued items under the submission threshold ({submission_threshold}): Exiting.")
@@ -51,10 +37,9 @@ def main():
 
 
 # =========================
-def get_previous_pubmed_submissions(tools_rds):
-    # mysql_conn = pub_oapi_tools_db.get_connection(tools_rds)
+def get_previous_pubmed_submissions():
     mysql_conn = pub_oapi_tools_db.get_connection(
-        env="prod", database="pubmed-linkout-db")
+        env=pub_oapi_tools_env, database=pub_oapi_tools_db_name)
 
     # Get the Item IDs already submitted
     with mysql_conn.cursor() as cursor:
@@ -68,10 +53,9 @@ def get_previous_pubmed_submissions(tools_rds):
 
 
 # Connects to Elements DB, create temp table w/ linkout IDs, get new pubs
-def get_new_pmid_pubs(elements_reporting_db, submitted_ids):
+def get_new_pmid_pubs(submitted_ids):
+    mssql_conn = ucpms_db.get_connection(env=ucpms_db_env)
 
-    # mssql_conn = ucpms_db.get_connection(elements_reporting_db)
-    mssql_conn = ucpms_db.get_connection(env="prod")
     with mssql_conn.cursor() as cursor:
         print("Creating temp table with submitted IDs.")
         cursor.execute("CREATE TABLE #linkout_ids (id varchar(16) COLLATE Latin1_General_CI_AS)")
@@ -117,10 +101,9 @@ def get_new_pmid_pubs(elements_reporting_db, submitted_ids):
     return new_eschol_pubmed_items
 
 
-def add_new_items_to_logging_db(tools_rds, new_eschol_pubmed_items):
-    # mysql_conn = pub_oapi_tools_db.get_connection(tools_rds)
+def add_new_items_to_logging_db(new_eschol_pubmed_items):
     mysql_conn = pub_oapi_tools_db.get_connection(
-        env="prod", database="pubmed-linkout-db")
+        env=pub_oapi_tools_env, database=pub_oapi_tools_db_name)
 
     # Get the Item IDs already submitted
     print(f"Adding {len(new_eschol_pubmed_items)} new items to the pmid logging db.")

--- a/enqueue_new_pubmed_items_elements.py
+++ b/enqueue_new_pubmed_items_elements.py
@@ -3,7 +3,8 @@
 
 from pub_oapi_tools_common import aws_lambda
 from pub_oapi_tools_common import ucpms_db
-from pub_oapi_toosl_common import pub_oapi_tools_db
+from pub_oapi_tools_common import pub_oapi_tools_db
+
 import submit_new_pubmed_items
 
 submission_threshold = 250

--- a/enqueue_new_pubmed_items_elements.py
+++ b/enqueue_new_pubmed_items_elements.py
@@ -52,7 +52,9 @@ def main():
 
 # =========================
 def get_previous_pubmed_submissions(tools_rds):
-    mysql_conn = pub_oapi_tools_db.get_connection(tools_rds)
+    # mysql_conn = pub_oapi_tools_db.get_connection(tools_rds)
+    mysql_conn = pub_oapi_tools_db.get_connection(
+        env="prod", database="pubmed-linkout-db")
 
     # Get the Item IDs already submitted
     with mysql_conn.cursor() as cursor:
@@ -68,7 +70,8 @@ def get_previous_pubmed_submissions(tools_rds):
 # Connects to Elements DB, create temp table w/ linkout IDs, get new pubs
 def get_new_pmid_pubs(elements_reporting_db, submitted_ids):
 
-    mssql_conn = ucpms_db.get_connection(elements_reporting_db)
+    # mssql_conn = ucpms_db.get_connection(elements_reporting_db)
+    mssql_conn = ucpms_db.get_connection(env="prod")
     with mssql_conn.cursor() as cursor:
         print("Creating temp table with submitted IDs.")
         cursor.execute("CREATE TABLE #linkout_ids (id varchar(16) COLLATE Latin1_General_CI_AS)")
@@ -115,7 +118,9 @@ def get_new_pmid_pubs(elements_reporting_db, submitted_ids):
 
 
 def add_new_items_to_logging_db(tools_rds, new_eschol_pubmed_items):
-    mysql_conn = pub_oapi_tools_db.get_connection(tools_rds)
+    # mysql_conn = pub_oapi_tools_db.get_connection(tools_rds)
+    mysql_conn = pub_oapi_tools_db.get_connection(
+        env="prod", database="pubmed-linkout-db")
 
     # Get the Item IDs already submitted
     print(f"Adding {len(new_eschol_pubmed_items)} new items to the pmid logging db.")

--- a/enqueue_new_pubmed_items_elements.py
+++ b/enqueue_new_pubmed_items_elements.py
@@ -1,9 +1,9 @@
 # LinkOut submission documentation
 # https://www.ncbi.nlm.nih.gov/books/NBK3812/
 
-from pub_oapi_tools_common import parameter_store_connect
-import pymysql
-import pyodbc
+from pub_oapi_tools_common import aws_lambda
+from pub_oapi_tools_common import ucpms_db
+from pub_oapi_toosl_common import pub_oapi_tools_db
 import submit_new_pubmed_items
 
 submission_threshold = 250
@@ -20,30 +20,8 @@ creds = {
         'names': ['server', 'pubmed-linkout-db', 'user', 'password']}
 }
 
-creds = parameter_store_connect.get_parameters(creds)
-
-
-# =========================
-# Get Connections
-def get_logging_db_connection(linkout_db):
-    return pymysql.connect(
-        host=linkout_db['server'],
-        user=linkout_db['user'],
-        password=linkout_db['password'],
-        database=linkout_db['pubmed-linkout-db'],
-        cursorclass=pymysql.cursors.DictCursor)
-
-
-def get_elements_report_db_connection(elements_db):
-    mssql_conn = pyodbc.connect(
-        driver=elements_db['driver'],
-        server=(elements_db['server'] + ',1433'),
-        database=elements_db['database'],
-        uid=elements_db['user'],
-        pwd=elements_db['password'],
-        trustservercertificate='yes')
-    mssql_conn.autocommit = True  # Required when queries use TRANSACTION
-    return mssql_conn
+creds = aws_lambda.get_parameters(creds)
+creds['linkout_db']['database'] = creds['linkout_db']['pubmed-linkout-db']
 
 
 # =========================
@@ -52,7 +30,7 @@ def main():
     # Get the pubs we've already submitted - returns a list of eschol_ids.
     submitted_ids = get_previous_pubmed_submissions(creds['linkout_db'])
 
-    # Get newly-added eSchol pubmed items;
+    # Get newly-added eSchol pubmed items
     # Add them to the logging db
     # Check the total number of enqueued items
     new_pubmed_items = get_new_pmid_pubs(creds['elements_db'], submitted_ids)
@@ -73,7 +51,7 @@ def main():
 
 # =========================
 def get_previous_pubmed_submissions(tools_rds):
-    mysql_conn = get_logging_db_connection(tools_rds)
+    mysql_conn = pub_oapi_tools_db.get_connection(tools_rds)
 
     # Get the Item IDs already submitted
     with mysql_conn.cursor() as cursor:
@@ -86,13 +64,11 @@ def get_previous_pubmed_submissions(tools_rds):
     return submitted_ids
 
 
+# Connects to Elements DB, create temp table w/ linkout IDs, get new pubs
 def get_new_pmid_pubs(elements_reporting_db, submitted_ids):
 
-    # connect to the mySql db
-    mssql_conn = get_elements_report_db_connection(elements_reporting_db)
+    mssql_conn = ucpms_db.get_connection(elements_reporting_db)
     with mssql_conn.cursor() as cursor:
-        print("Connected to Elements Reporting DB.")
-
         print("Creating temp table with submitted IDs.")
         cursor.execute("CREATE TABLE #linkout_ids (id varchar(16) COLLATE Latin1_General_CI_AS)")
         temp_table_insert = "INSERT INTO #linkout_ids (id) VALUES (?)"
@@ -138,7 +114,7 @@ def get_new_pmid_pubs(elements_reporting_db, submitted_ids):
 
 
 def add_new_items_to_logging_db(tools_rds, new_eschol_pubmed_items):
-    mysql_conn = get_logging_db_connection(tools_rds)
+    mysql_conn = pub_oapi_tools_db.get_connection(tools_rds)
 
     # Get the Item IDs already submitted
     print(f"Adding {len(new_eschol_pubmed_items)} new items to the pmid logging db.")

--- a/submit_new_pubmed_items.py
+++ b/submit_new_pubmed_items.py
@@ -2,10 +2,9 @@
 # https://www.ncbi.nlm.nih.gov/books/NBK3812/
 
 from pub_oapi_tools_common import aws_lambda
-from pub_oapi_toosl_common import pub_oapi_tools_db
+from pub_oapi_tools_common import pub_oapi_tools_db
 
 import datetime
-import pymysql
 import xml.etree.ElementTree as ET
 from ftplib import FTP
 import subprocess

--- a/submit_new_pubmed_items.py
+++ b/submit_new_pubmed_items.py
@@ -1,4 +1,9 @@
-from pub_oapi_tools_common import parameter_store_connect
+# LinkOut submission documentation
+# https://www.ncbi.nlm.nih.gov/books/NBK3812/
+
+from pub_oapi_tools_common import aws_lambda
+from pub_oapi_toosl_common import pub_oapi_tools_db
+
 import datetime
 import pymysql
 import xml.etree.ElementTree as ET
@@ -20,17 +25,8 @@ creds = {
     }
 }
 
-creds = parameter_store_connect.get_parameters(creds)
-
-
-# =========================
-def get_logging_db_connection(linkout_db):
-    return pymysql.connect(
-        host=linkout_db['server'],
-        user=linkout_db['user'],
-        password=linkout_db['password'],
-        database=linkout_db['pubmed-linkout-db'],
-        cursorclass=pymysql.cursors.DictCursor)
+creds = aws_lambda.get_parameters(creds)
+creds['linkout_db']['database'] = creds['linkout_db']['pubmed-linkout-db']
 
 
 # =========================
@@ -65,7 +61,7 @@ def main():
 
 
 def get_new_items_for_submission(linkout_db):
-    mysql_conn = get_logging_db_connection(linkout_db)
+    mysql_conn = pub_oapi_tools_db.getconnection(linkout_db)
 
     print("Connected to logging DB. Getting new items for submission.")
     with mysql_conn.cursor() as cursor:
@@ -150,7 +146,7 @@ def upload_submission_file_to_ftp(ftp_creds, submission_file_with_path, submissi
 
 
 def update_logging_db(linkout_db, submission_file):
-    mysql_conn = get_logging_db_connection(linkout_db)
+    mysql_conn = pub_oapi_tools_db.get_connection(linkout_db)
 
     print("Connected to logging DB. Updating submitted items.")
     with mysql_conn.cursor() as cursor:
@@ -165,12 +161,19 @@ def update_logging_db(linkout_db, submission_file):
     mysql_conn.close()
 
 
+# Set up the mail process with attachment and email recipients
 def send_notification_email(emails, submission_file, new_item_count):
-    # Set up the mail process with attachment and email recipients
     subprocess_setup = ['mail', '-s', 'New UC eScholarship .xml file added to linkout FTP']
     subprocess_setup += [emails['devin'], emails['oapolicy-help']]
+    input_byte_string = get_email_body_text(submission_file, new_item_count)
 
-    input_byte_string = b'''
+    # Run the subprocess
+    subprocess.run(subprocess_setup, input=input_byte_string, capture_output=True)
+
+
+# Split off into its own function bc of the weird formatting
+def get_email_body_text(submission_file, new_item_count):
+    return(b'''
 Hello Pubmed,
 
 An .xml file containing new publications for LinkOut has been added to our "holdings" folder on the FTP:
@@ -182,11 +185,7 @@ Thank you!
 
 
 Future-proofing Note:
-This automated message is sent from the pubmed-linkout tool: https://github.com/eScholarship/pubmed-linkout 
-'''
-
-    # Run the subprocess
-    subprocess.run(subprocess_setup, input=input_byte_string, capture_output=True)
+This automated message is sent from the pubmed-linkout tool: https://github.com/eScholarship/pubmed-linkout ''')
 
 
 # =========================

--- a/submit_new_pubmed_items.py
+++ b/submit_new_pubmed_items.py
@@ -1,49 +1,40 @@
-import boto3
+from pub_oapi_tools_common import parameter_store_connect
 import datetime
 import pymysql
 import xml.etree.ElementTree as ET
 from ftplib import FTP
 import subprocess
 
-session = boto3.Session()
+
+# =========================
+creds = {
+    'linkout_db': {
+        'folder': 'pub-oapi-tools/tools-rds',
+        'env': 'prod',
+        'names': ['server', 'pubmed-linkout-db', 'user', 'password']},
+    'pubmed_ftp': {
+        'folder': 'pub-oapi-tools/pubmed-linkout-ftp'},
+    'emails': {
+        'folder': 'pub-oapi-tools/emails',
+        'names': ['devin', 'oapolicy-help']
+    }
+}
+
+creds = parameter_store_connect.get_parameters(creds)
 
 
-def get_ssm_parameters(folder, names):
-    print("Connect to SSM for parameters")
-    ssm_client = session.client(service_name='ssm', region_name='us-west-2')
-
-    param_names = [f"{folder}{name}" for name in names]
-    response = ssm_client.get_parameters(Names=param_names, WithDecryption=True)
-
-    param_values = {
-        (param['Name'].split('/')[-1]): param['Value']
-        for param in response['Parameters']}
-
-    return param_values
-
-
-def get_logging_db_connection(creds):
+# =========================
+def get_logging_db_connection(linkout_db):
     return pymysql.connect(
-        host=creds['server'],
-        user=creds['user'],
-        password=creds['password'],
-        database=creds['pubmed-linkout-db'],
+        host=linkout_db['server'],
+        user=linkout_db['user'],
+        password=linkout_db['password'],
+        database=linkout_db['pubmed-linkout-db'],
         cursorclass=pymysql.cursors.DictCursor)
 
 
 # =========================
 def main():
-    tools_rds_creds = get_ssm_parameters(
-        folder="/pub-oapi-tools/tools-rds/prod/",
-        names=['server', 'pubmed-linkout-db', 'user', 'password'])
-
-    pubmed_linkout_ftp_creds = get_ssm_parameters(
-        folder="/pub-oapi-tools/pubmed-linkout-ftp/",
-        names=['url', 'user', 'password', 'dir'])
-
-    emails = get_ssm_parameters(
-        folder="/pub-oapi-tools/emails/",
-        names=['devin', 'oapolicy-help'])
 
     # Runtime string for dirs, filenames, logging DB
     run_time = datetime.datetime.now()
@@ -55,26 +46,26 @@ def main():
     submission_file = f"{run_date}_eschol_linkout_resource.xml"
 
     # Get the new items enqueued for submission
-    new_items = get_new_items_for_submission(tools_rds_creds)
+    new_items = get_new_items_for_submission(creds['linkout_db'])
     new_item_count = len(new_items)
 
     # Create the XML file
     submission_file_with_path = create_submission_file(new_items, output_dir, submission_file)
 
     # Send to PubMed FTP
-    upload_submission_file_to_ftp(pubmed_linkout_ftp_creds, submission_file_with_path, submission_file)
+    upload_submission_file_to_ftp(creds['pubmed_ftp'], submission_file_with_path, submission_file)
 
     # Update the logging DB
-    update_logging_db(tools_rds_creds, submission_file)
+    update_logging_db(creds['linkout_db'], submission_file)
 
     # Email stakeholders
-    send_notification_email(emails, submission_file, new_item_count)
+    send_notification_email(creds['emails'], submission_file, new_item_count)
 
     print("Program complete. Exiting.")
 
 
-def get_new_items_for_submission(creds):
-    mysql_conn = get_logging_db_connection(creds)
+def get_new_items_for_submission(linkout_db):
+    mysql_conn = get_logging_db_connection(linkout_db)
 
     print("Connected to logging DB. Getting new items for submission.")
     with mysql_conn.cursor() as cursor:
@@ -121,7 +112,6 @@ def create_xml_data(new_items):
         link = ET.SubElement(link_set, "Link")
         ET.SubElement(link, "LinkId").text = item['eschol_id']
         ET.SubElement(link, "ProviderId").text = "7383"
-        # ET.SubElement(link, "IconURL").text = "https://escholarship.org/images/pubmed_linkback.png"
         ET.SubElement(link, "IconUrl").text = "&icon.url;"
 
         # Link > ObjectSelector
@@ -134,7 +124,6 @@ def create_xml_data(new_items):
 
         # Link > ObjectURL
         object_url = ET.SubElement(link, "ObjectUrl")
-        # ET.SubElement(object_url, "Rule").text = f"https://escholarship.org/uc/item/{item['eschol_id']}"
         ET.SubElement(object_url, "Base").text = '&base.url;'
         ET.SubElement(object_url, "Rule").text = item['eschol_id'][2:]
         ET.SubElement(object_url, "UrlName").text = "Full text from University of California eScholarship"
@@ -143,12 +132,15 @@ def create_xml_data(new_items):
     return link_set
 
 
-def upload_submission_file_to_ftp(creds, submission_file_with_path, submission_file):
+def upload_submission_file_to_ftp(ftp_creds, submission_file_with_path, submission_file):
     # https://docs.python.org/3/library/ftplib.html#ftplib.FTP.storbinary
 
     print("Connecting to PubMed Linkout FTP.")
-    ftp = FTP(creds['url'], creds['user'], creds['password'])  # should return 230 successful login
-    ftp.cwd(creds['dir'])  # should return 250 successful dir change
+    ftp = FTP(
+        ftp_creds['url'],
+        ftp_creds['user'],
+        ftp_creds['password'])  # should return 230 successful login
+    ftp.cwd(ftp_creds['dir'])  # should return 250 successful dir change
 
     print(f"Transferring: {submission_file}")
     with open(submission_file_with_path, 'rb') as file:
@@ -157,8 +149,8 @@ def upload_submission_file_to_ftp(creds, submission_file_with_path, submission_f
     ftp.quit()
 
 
-def update_logging_db(creds, submission_file):
-    mysql_conn = get_logging_db_connection(creds)
+def update_logging_db(linkout_db, submission_file):
+    mysql_conn = get_logging_db_connection(linkout_db)
 
     print("Connected to logging DB. Updating submitted items.")
     with mysql_conn.cursor() as cursor:

--- a/submit_new_pubmed_items.py
+++ b/submit_new_pubmed_items.py
@@ -9,13 +9,11 @@ import xml.etree.ElementTree as ET
 from ftplib import FTP
 import subprocess
 
+pub_oapi_tools_env = "prod"
+pub_oapi_tools_db_name = "pubmed-linkout-db"
 
 # =========================
 creds = {
-    'linkout_db': {
-        'folder': 'pub-oapi-tools/tools-rds',
-        'env': 'prod',
-        'names': ['server', 'pubmed-linkout-db', 'user', 'password']},
     'pubmed_ftp': {
         'folder': 'pub-oapi-tools/pubmed-linkout-ftp'},
     'emails': {
@@ -23,9 +21,7 @@ creds = {
         'names': ['devin', 'oapolicy-help']
     }
 }
-
 creds = aws_lambda.get_parameters(creds)
-creds['linkout_db']['database'] = creds['linkout_db']['pubmed-linkout-db']
 
 
 # =========================
@@ -41,7 +37,7 @@ def main():
     submission_file = f"{run_date}_eschol_linkout_resource.xml"
 
     # Get the new items enqueued for submission
-    new_items = get_new_items_for_submission(creds['linkout_db'])
+    new_items = get_new_items_for_submission()
     new_item_count = len(new_items)
 
     # Create the XML file
@@ -51,7 +47,7 @@ def main():
     upload_submission_file_to_ftp(creds['pubmed_ftp'], submission_file_with_path, submission_file)
 
     # Update the logging DB
-    update_logging_db(creds['linkout_db'], submission_file)
+    update_logging_db(submission_file)
 
     # Email stakeholders
     send_notification_email(creds['emails'], submission_file, new_item_count)
@@ -59,8 +55,9 @@ def main():
     print("Program complete. Exiting.")
 
 
-def get_new_items_for_submission(linkout_db):
-    mysql_conn = pub_oapi_tools_db.getconnection(linkout_db)
+def get_new_items_for_submission():
+    mysql_conn = pub_oapi_tools_db.getconnection(
+        env=pub_oapi_tools_env, database=pub_oapi_tools_db_name)
 
     print("Connected to logging DB. Getting new items for submission.")
     with mysql_conn.cursor() as cursor:
@@ -144,8 +141,9 @@ def upload_submission_file_to_ftp(ftp_creds, submission_file_with_path, submissi
     ftp.quit()
 
 
-def update_logging_db(linkout_db, submission_file):
-    mysql_conn = pub_oapi_tools_db.get_connection(linkout_db)
+def update_logging_db(submission_file):
+    mysql_conn = pub_oapi_tools_db.getconnection(
+        env=pub_oapi_tools_env, database=pub_oapi_tools_db_name)
 
     print("Connected to logging DB. Updating submitted items.")
     with mysql_conn.cursor() as cursor:


### PR DESCRIPTION
This is the first example of how the pub-oapi-tools will be use the new common package https://github.com/eScholarship/pub-oapi-tools-common to get connections to various external source.

The major changes to the code are:
- Connections: All "get XYZ connection" functions now handled in the commons packages.
- Creds/Paramters: Rather than in-line with the function `get_ssm_parameters(folder, names)`, the specific creds needed are specified as a dict structure and passed to the common package that calls the lambda.